### PR TITLE
Embed mime-types in executable

### DIFF
--- a/src/camo.cr
+++ b/src/camo.cr
@@ -8,10 +8,6 @@ class Camo
   MiB = 1024 * KiB
   GiB = 1024 * MiB
 
-  ACCEPTED_MIME_TYPES = Array(String).from_json(
-    File.read(File.join(__DIR__, "camo", "mime-types.json"))
-  )
-
   # NOTE: use Atomic after parallelism
   @total_requests = 0
   @processing_requests = 0

--- a/src/camo/request.cr
+++ b/src/camo/request.cr
@@ -87,7 +87,7 @@ struct Camo::Request
     return error(500, "No Content-Type returned") unless content_type
 
     content_type_prefix = content_type.split(';', 2)[0].downcase
-    return error(500, "Non-image Content-Type returned: #{content_type_prefix}") unless ACCEPTED_MIME_TYPES.includes? content_type_prefix
+    return error(500, "Non-image Content-Type returned: #{content_type_prefix}") unless @config.accepted_mime_types.includes? content_type_prefix
 
     copy_header "Content-Type"
     copy_header "Cache-Control"


### PR DESCRIPTION
camo.cr will default the mime-types list to the one found during compile time if it doesn't found a list at runtime.

This is useful for deploying camo to an external environment without having to copy any dependency at all.