### PR TITLE
Proxy only a share of requests

### DIFF
--- a/src/camo/config.cr
+++ b/src/camo/config.cr
@@ -10,6 +10,7 @@ class Camo::Config
   getter timing_allow_origin : String?
   getter debug = false
   getter accepted_mime_types : Array(String)
+  getter accept_ratio : Float64 = 1f64
 
   def initialize(@key)
     @accepted_mime_types = default_accepted_mime_types
@@ -88,6 +89,12 @@ class Camo::Config
     else
       # default to built-in mime-types list
       @accepted_mime_types = default_accepted_mime_types
+    end
+
+    if accept_ratio = ENV["CAMO_ACCEPT_RATIO"]?
+      accept_ratio = accept_ratio.to_f?
+      raise Error.new("ENV[\"CAMO_ACCEPT_RATIO\"] was not a float") unless accept_ratio
+      @accept_ratio = accept_ratio
     end
   end
 

--- a/src/camo/request.cr
+++ b/src/camo/request.cr
@@ -25,6 +25,10 @@ struct Camo::Request
       return error(400, message)
     end
 
+    if @config.accept_ratio < 1f64 && rand > @config.accept_ratio
+      return redirect(dest_url)
+    end
+
     # Finally, we perform the HTTP request
     begin
       proxy_request(URI.parse(dest_url))
@@ -139,5 +143,10 @@ struct Camo::Request
     @response.status_code = status_code
 
     nil
+  end
+
+  private def redirect(dest_url)
+    @response.status_code = 302
+    @response.headers["Location"] = dest_url
   end
 end

--- a/src/camo/request.cr
+++ b/src/camo/request.cr
@@ -113,7 +113,7 @@ struct Camo::Request
   end
 
   private def parse_url
-    path_parts = @request.path.chomp('/').lchomp('/').split('/', 2)
+    path_parts = @request.path.chomp('/').lchop('/').split('/', 2)
 
     case path_parts.size
     when 1


### PR DESCRIPTION
I know this is a weird one, so I'll explain the rationale.

If you're about to deploy camo for use on an existing environment/website, you'll probably want to test it's workload first. You could do that by specifying in "the client" which requests to serve through camo, but that's client dependent. This PR allows you to specify that option in camo itself, and return HTTP 302 redirects for the requests that don't get proxied.

There's an overhead against avoiding camo within the client - you are making an extra request when no proxying -, but you get the stats on how many requests you need to support without paying for the extra bandwidth.

I currently am in this scenario - it's easier to me to fiddle with camo.cr than a myBB PHP plugin -, so that's why I did this. I totally understand if you think this doesn't fit in camo.cr and want to reject the PR - I'm just sharing :)